### PR TITLE
Fix typo in comment explaining the Monte Carlo method

### DIFF
--- a/examples/misc/lib/overview_pi.dart
+++ b/examples/misc/lib/overview_pi.dart
@@ -20,8 +20,8 @@ Stream<double> computePi({int batch = 100000}) async* {
     final ratio = count / total;
 
     // Area of a circle is A = π⋅r², therefore π = A/r².
-    // So, when given random points with x ∈ <0,1>,
-    // y ∈ <0,1>, the ratio of those inside a unit circle
+    // So, when given random points with x ∈ <-1,1>,
+    // y ∈ <-1,1>, the ratio of those inside a unit circle
     // should approach π / 4. Therefore, the value of π
     // should be:
     yield ratio * 4;


### PR DESCRIPTION
Fix Typo in Monte Carlo method example 

The Monte Carlo ratio formula assumes a full circle inscribed in a square centered at the origin, with x and y values ranging from -1 to 1.

Fixes <#6856>

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] This PR doesn't contain automatically generated corrections or text (Grammarly, LLMs, and similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn't use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
